### PR TITLE
Add Joint 6, 7 support for move all joints

### DIFF
--- a/Firmware/DexRun.c
+++ b/Firmware/DexRun.c
@@ -4570,14 +4570,13 @@ int ParseInput(char *iString)
 					p5=strtok (NULL, delimiters);
 					
 					p6=strtok (NULL, delimiters);
-					if (p6) SetGripperRoll(atoi(p6));
+					if (p6 && 'x'!=p6[0]) SetGripperRoll(atoi(p6));
+					//if(p6 != NULL){ printf("p6 %s\n",p6); }
+					//else{ printf("p6 doesn't exist\n"); }
 					p7=strtok (NULL, delimiters);
-					if (p7) SetGripperSpan(atoi(p7));
-					// if(p6 != NULL){
-					// 	printf("p6 exists");
-					// }else{
-					// 	printf("p6 doesn't exists");
-					// }
+					if (p7 && 'x'!=p7[0]) SetGripperSpan(atoi(p7));
+					//if(p7 != NULL){ printf("p7 %s\n",p7); }
+					//else{ printf("p7 doesn't exist\n"); }
 					
 					if(p1!=NULL && p2!=NULL && p3!=NULL && p4!=NULL && p5!=NULL)						
 						MoveRobot(atoi(p1),atoi(p2),atoi(p3),atoi(p4),atoi(p5),BLOCKING_MOVE);

--- a/Firmware/DexRun.c
+++ b/Firmware/DexRun.c
@@ -2291,7 +2291,8 @@ void *RealtimeMonitor(void *arg)
 
 void SetGripperRoll(int Possition)
 {
-   SendGoalSetPacket(Possition, 3);
+	SendGoalSetPacket(Possition, 3);
+   	//printf("Moving Servo 3 to %u\n",Possition);
 
 	/*int ServoSpan=(SERVO_HI_BOUND-SERVO_LOW_BOUND)/360;
 	mapped[END_EFFECTOR_IO]=80;
@@ -2304,6 +2305,7 @@ void SetGripperSpan(int Possition)
 {
 	//SendReadPacket(3,30,21);       
 	SendGoalSetPacket(Possition, 1);
+	//printf("Moving Servo 1 to %u\n",Possition);
 
 /*	int ServoSpan=(SERVO_HI_BOUND-SERVO_LOW_BOUND)/360;
 	mapped[END_EFFECTOR_IO]=80;
@@ -4568,6 +4570,9 @@ int ParseInput(char *iString)
 					p5=strtok (NULL, delimiters);
 					
 					p6=strtok (NULL, delimiters);
+					if (p6) SetGripperRoll(atoi(p6));
+					p7=strtok (NULL, delimiters);
+					if (p7) SetGripperSpan(atoi(p7));
 					// if(p6 != NULL){
 					// 	printf("p6 exists");
 					// }else{


### PR DESCRIPTION
Accept 2 additional values on the "a" (move all joints) instruction and send those out to set gripper roll and span. This integrates the 2 new servo joints into the move all joints system, bringing it from 5 joints to 7 joints.

However, DDE may not correctly send these values as of 2.5.3. This may happen even when only 5 values are sent in the DDE `Dexter.move_all_joints` command as it will try to guess where Joints 6 and 7 were before. There are two problems:

1. DDE is incorrectly converting the Joint 6 and 7 values. It seems to always send 3600 for joint 6 and 7200 for joint 7. There is some question as to what the values sent should be. Either:

- The value should be in arcseconds and the firmware should be updated to convert that to degrees for the Dynamixel servo, or

- The value should be sent in degrees and the Firmware should just pass it through. (current)

2. The initial values for these joints may not be set correctly.

Also, because the SetParam EERoll and EESpan commands also set the End Effector positions (which are Joints 6 and 7), DDE may not correctly track the commanded position, and if a 5 axes Dexter.move_all_joints command is issued, it will assume the user wants Joint 6 and 7 at their last known position, which may be different from where they are now due to the EERoll and EESpan SetParm commands. Either:

1. DDE could just NOT send positions when it isn't given position for higher order joints. This seems safest.

2. DDE could monitor the EERoll and EESpan commands to stay in the loop on their commanded positions. 

See:

https://github.com/cfry/dde/issues/35

https://github.com/HaddingtonDynamics/Dexter/wiki/set-parameter-oplet